### PR TITLE
changes to fit for bootstrap 4.0.0-beta

### DIFF
--- a/assets/css/vendor/bootstrap_selection.scss
+++ b/assets/css/vendor/bootstrap_selection.scss
@@ -1,12 +1,12 @@
 // Core variables and mixins
+@import '../../vendor/bootstrap/scss/functions';
 @import '../../vendor/bootstrap/scss/variables';
 
 // Reset and dependencies
-@import '../../vendor/bootstrap/scss/normalize';
 @import '../../vendor/bootstrap/scss/mixins';
 
 // Core CSS
-// @import '../../vendor/bootstrap/scss/reboot';
+@import '../../vendor/bootstrap/scss/reboot';
 @import '../../vendor/bootstrap/scss/grid';
 
 // Utility classes


### PR DESCRIPTION
normalize.scss is gone in beta..
functions.scss is needed e.g. in variables -> darken()